### PR TITLE
Fix collecting scripts for custom SCRIPTS_DIR

### DIFF
--- a/gort.go
+++ b/gort.go
@@ -41,11 +41,11 @@ func init() {
 	scriptsDir = os.Getenv("SCRIPTS_DIR")
 	if scriptsDir == "" {
 		scriptsDir = defaultScriptsDir
-		if _, err := os.Stat(scriptsDir); os.IsNotExist(err) {
-			log.Panic(err)
-		}
-		scripts = utils.ScanScripts(scriptsDir)
 	}
+	if _, err := os.Stat(scriptsDir); os.IsNotExist(err) {
+		log.Panic(err)
+	}
+	scripts = utils.ScanScripts(scriptsDir)
 }
 
 func main() {


### PR DESCRIPTION
The idea is, in current code we collect scripts only if the SCRIPTS_DIR was not specified, thus making it's usage impossible
